### PR TITLE
Fixed 64-bit windows install

### DIFF
--- a/install.js
+++ b/install.js
@@ -8,6 +8,10 @@ var fs = require('fs')
 
 var platform = os.platform()
 var arch = os.arch()
+if ('win32' === platform) {
+  // 64-bit is not available under windows.
+  arch = 'ia32';
+}
 var version = '0.19.5'
 var name = 'atom-shell-v'+version+'-'+platform+'-'+arch+'.zip'
 var url = 'https://github.com/atom/atom-shell/releases/download/v'+version+'/atom-shell-v'+version+'-'+platform+'-'+arch+'.zip'


### PR DESCRIPTION
64-bit version is not available under Windows, so install fails with 404 download error. Fixed by patching windows install.
