### PR TITLE
Added target arch support

### DIFF
--- a/install.js
+++ b/install.js
@@ -23,8 +23,11 @@ var paths = {
 
 if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
-// downloads if not cached
-download({version: version}, extractFile)
+if (process.env.npm_config_arch) {
+    download({version: version, arch: process.env.npm_config_arch}, extractFile)
+} else {
+    download({version: version}, extractFile)
+}
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {


### PR DESCRIPTION
Previously electron-prebuilt would download the prebuilt binaries
for the architecture native to the platform. However there are
cases where being able to download for another architecture is
favourable.
This patch adds support for setting the architecture through
npm's --arch= parameter. (Issue #53)