### PR TITLE
Allow specifying STRICT_SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Now you can just run `electron` to run electron:
 electron
 ```
 
-If you need to use an HTTP proxy you can [set these environment variables](https://github.com/request/request/tree/f0c4ec061141051988d1216c24936ad2e7d5c45d#controlling-proxy-behaviour-using-environment-variables)
+If you need to use an HTTP proxy you can [set these environment variables](https://github.com/request/request/tree/f0c4ec061141051988d1216c24936ad2e7d5c45d#controlling-proxy-behaviour-using-environment-variables). To disable strict-ssl (for HTTPS proxies), use an environment variable "STRICT_SSL" or "strict_ssl" set to "false".
 
 If you want to change the architecture that is downloaded (e.g., `ia32` on an `x64` machine), you can use the `--arch` flag with npm install or set the `npm_config_arch` environment variable:
 ```

--- a/install.js
+++ b/install.js
@@ -23,8 +23,14 @@ var paths = {
 
 if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
+var strictSSLEnv = process.env.STRICT_SSL || process.env.strict_ssl
+var strictSSL
+if (strictSSLEnv && strictSSLEnv.toLowerCase() === 'false') {
+  strictSSL = false
+}
+
 // downloads if not cached
-download({version: version, arch: process.env.npm_config_arch}, extractFile)
+download({version: version, arch: process.env.npm_config_arch, strictSSL: strictSSL}, extractFile)
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {


### PR DESCRIPTION
This cannot be overridden by environment variables like HTTPS_PROXY and electron-download already forces it to false and provides a way to set an option for it. This change picks up STRICT_SSL or strict_ssl and if set to "false" it switches off strict ssl.