### PR TITLE
Added option to explicitly set the version of electron prebuilt using package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 path.txt
 .DS_Store
+/.idea

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ If you want to change the architecture that is downloaded (e.g., `ia32` on an `x
 npm install --arch=ia32 electron-prebuilt
 ```
 
+## Installation - options
+
+You can override the default options for the downloader by creating an entry in the package.json file in the root of your project
+
+```
+{
+ "electron_prebuilt": {
+    "version" : "0.35.4",
+    "arch" : "win32",
+    "strict_ssl" : true
+ }
+}
+```
+
 ## About
 
 Works on Mac, Windows and Linux OSes that Electron supports (e.g. Electron [does not support Windows XP](https://github.com/atom/electron/issues/691)).

--- a/install.js
+++ b/install.js
@@ -53,7 +53,7 @@ function getProperties() {
 
     var inf = (manifest && manifest['electron-prebuilt']) ? manifest['electron-prebuilt'] : {};
 
-    var arch = inf.runtime_arch || process.env.npm_config_arch;
+    var arch = inf.arch || process.env.npm_config_arch;
     var strictSSL = inf.strict_ssl || process.env.npm_config_strict_ssl;
     var version = inf.version || version;
 

--- a/install.js
+++ b/install.js
@@ -1,50 +1,91 @@
 #!/usr/bin/env node
 
 // maintainer note - x.y.z-ab version in package.json -> x.y.z
-var version = require('./package').version.replace(/-.*/, '')
+var version = require('./package').version.replace(/-.*/, '');
 
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var extract = require('extract-zip')
-var download = require('electron-download')
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var extract = require('extract-zip');
+var findProjectRoot = require('find-project-root');
+var download = require('electron-download');
 
-var installedVersion = null
+
+var nodeRootdir = findProjectRoot(process.cwd(), {
+    maxDepth: 12
+});
+
+var installedVersion = null;
 try {
-  installedVersion = fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '')
+    installedVersion = fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '')
 } catch (err) {
-  // do nothing
+    // do nothing
 }
 
-var platform = os.platform()
+var platform = os.platform();
 
-function onerror (err) {
-  throw err
+function onerror(err) {
+    throw err
 }
 
 var paths = {
-  darwin: 'dist/Electron.app/Contents/MacOS/Electron',
-  freebsd: 'dist/electron',
-  linux: 'dist/electron',
-  win32: 'dist/electron.exe'
-}
+    darwin: 'dist/Electron.app/Contents/MacOS/Electron',
+    freebsd: 'dist/electron',
+    linux: 'dist/electron',
+    win32: 'dist/electron.exe'
+};
 
-if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
+if (!paths[platform]) throw new Error('Unknown platform: ' + platform);
 
 if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[platform]))) {
-  process.exit(0)
+    process.exit(0);
 }
 
+
+// get the properties
+
+function getProperties() {
+    try {
+        var manifest = require(path.join(nodeRootdir, "package.json"));
+    } catch (e) {
+    }
+
+
+    var inf = (manifest && manifest['electron-prebuilt']) ? manifest['electron-prebuilt'] : {};
+
+    var arch = inf.runtime_arch || process.env.npm_config_arch;
+    var strictSSL = inf.strict_ssl || process.env.npm_config_strict_ssl;
+    var version = inf.version || version;
+
+
+    return {
+        'version': version,
+        'arch': arch,
+        'strictSSL': strictSSL
+    };
+
+}
+
+
+// get the properties
+oProperties = getProperties();
+
 // downloads if not cached
-download({version: version, arch: process.env.npm_config_arch, strictSSL: process.env.npm_config_strict_ssl}, extractFile)
+download({
+    version: oProperties.version,
+    arch: oProperties.arch,
+    strictSSL: oProperties.strictSSL
+}, extractFile);
 
 // unzips and makes path.txt point at the correct executable
-function extractFile (err, zipPath) {
-  if (err) return onerror(err)
-  fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
-    if (err) return onerror(err)
-    extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
-      if (err) return onerror(err)
+function extractFile(err, zipPath) {
+    if (err) {
+        return onerror(err);
+    }
+    fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
+        if (err) return onerror(err);
+        extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
+            if (err) return onerror(err)
+        })
     })
-  })
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "main": "index.js",
   "dependencies": {
     "extract-zip": "^1.0.3",
-    "electron-download": "^1.0.0"
+    "electron-download": "^1.0.0",
+    "find-project-root": "^1.1.1"
   },
   "devDependencies": {
     "home-path": "^0.1.1",


### PR DESCRIPTION
This option allows you to explicitly set the version of electron prebuilt to be downloaded, this can be very vital because sometimes you need only a specific version and not the latest version without using environment variables.