### PR TITLE
Fix npm usage

### DIFF
--- a/install.js
+++ b/install.js
@@ -36,7 +36,7 @@ if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[pla
 }
 
 // downloads if not cached
-download({version: version, platform: process.env.npm_config_platform, arch: process.env.npm_config_arch, strictSSL: process.env.npm_config_strict_ssl}, extractFile)
+download({version: version, platform: process.env.npm_config_platform, arch: process.env.npm_config_arch, strictSSL: process.env.npm_config_strict_ssl === 'true'}, extractFile)
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {


### PR DESCRIPTION
As discussed in both #75 and #91, in particular [this comment](https://github.com/electron-userland/electron-prebuilt/pull/75#issuecomment-191115502). We can not use environment variables to reliably access npm configuration settings, instead we must require in the `npm` module and use its api.

This supercedes other pull requests that were trying to do the same thing.

Fixes #91
Closes #75