### PR TITLE
add whitespace trimming from Electron binary path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
 var path = require('path')
 
-module.exports = path.join(__dirname, fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8'))
+var binaryPath = fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8').trim()
+module.exports = path.join(__dirname, binaryPath)


### PR DESCRIPTION
The `path.txt` file was not allowed to contain trailing whitespace such as a new line.
