### PR TITLE
pass ELECTRON_ENV env variable to Electron. Closes #116

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,13 @@ node_js:
   - '0.10'
   - '0.12'
   - 'iojs'
+
+
+addons:
+  apt:
+    packages:
+      - xvfb
+
+before_install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/README.md
+++ b/README.md
@@ -87,20 +87,22 @@ var child = proc.spawn(electron)
 
 ## ELECTRON_ENV environment variable
 
-`electron` cli add an ELECTRON_ENV variable to the process environment of your Electron app, with the default value of 'development'. If parent process has an ELECTRON_ENV variable defined with a different value, that value is used instead.
+The `electron` CLI adds an `ELECTRON_ENV` environment variable with the default value of `'development'`. The variable is inherited if set in a parent process.
 
-When an Electron application is run, it can check the value of the environment variable and do different things based on the value. ELECTRON_ENV specifically is used (by convention) to state whether a particular environment is a production or a development environment. A common use-case is running additional debugging or logging code if running in a development environment.
+An Electron app can check the value of the environment variable and do different things based on the value. `ELECTRON_ENV` is used (by convention) to state whether a particular environment is a production or a development environment. A common use-case is running additional debugging or logging code if running in a development environment.
 
-You can use the following code to access the environment variable yourself so that you can perform your own checks and logic:
+You can check the variable like this:
 
 ```js
 var environment = process.env.ELECTRON_ENV
 ```
 
-Or alternatively you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) module.
+Alternatively you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) module.
 
 How to actually set the environment variable varies from operating system to operating system, and also depends on your user setup.
-If you want to set the environment variable as a one-off, you can do so from the command line:
+If you want to set the environment variable as a one-off, you can do so from the command-line:
 
-* linux & osx: `export ELECTRON_ENV=production`
-* windows: `set ELECTRON_ENV=production`
+* Linux & OS X: `export ELECTRON_ENV=production`
+* Windows: `set ELECTRON_ENV=production`
+
+You could find more details on [this guide](https://github.com/sindresorhus/guides/blob/master/set-environment-variables.md)

--- a/README.md
+++ b/README.md
@@ -84,3 +84,23 @@ console.log(electron)
 // spawn electron
 var child = proc.spawn(electron)
 ```
+
+## ELECTRON_ENV environment variable
+
+`electron` cli add an ELECTRON_ENV variable to the process environment of your Electron app, with the default value of 'development'. If parent process has an ELECTRON_ENV variable defined with a different value, that value is used instead.
+
+When an Electron application is run, it can check the value of the environment variable and do different things based on the value. ELECTRON_ENV specifically is used (by convention) to state whether a particular environment is a production or a development environment. A common use-case is running additional debugging or logging code if running in a development environment.
+
+You can use the following code to access the environment variable yourself so that you can perform your own checks and logic:
+
+```js
+var environment = process.env.ELECTRON_ENV
+```
+
+Or alternatively you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) module.
+
+How to actually set the environment variable varies from operating system to operating system, and also depends on your user setup.
+If you want to set the environment variable as a one-off, you can do so from the command line:
+
+* linux & osx: `export ELECTRON_ENV=production`
+* windows: `set ELECTRON_ENV=production`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ var environment = process.env.ELECTRON_ENV
 
 Alternatively you can use [electron-is-dev](https://github.com/sindresorhus/electron-is-dev) module.
 
-How to actually set the environment variable varies from operating system to operating system, and also depends on your user setup.
+How to actually set the environment variable varies by operating system, and also depends on your user setup.
 If you want to set the environment variable as a one-off, you can do so from the command-line:
 
 * Linux & OS X: `export ELECTRON_ENV=production`

--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,7 @@ var proc = require('child_process')
 var env = process.env
 env.ELECTRON_ENV = env.ELECTRON_ENV || 'development'
 
-var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit', env: env})
+var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'})
 child.on('close', function (code) {
   process.exit(code)
 })

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,10 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'})
+var env = process.env
+env.ELECTRON_ENV = env.ELECTRON_ENV || 'development'
+
+var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit', env: env})
 child.on('close', function (code) {
   process.exit(code)
 })

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -1,0 +1,2 @@
+console.log(process.env.ELECTRON_ENV)
+process.exit(0)

--- a/test/index.js
+++ b/test/index.js
@@ -8,8 +8,9 @@ var execFile = require('child_process').execFile
 tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
-    t.equal(stderr, '')
-    t.equal(err, null)
+    if (err) {
+      return t.end(err)
+    }
     t.equal(stdout.toString(), 'development\n')
     t.end()
   })
@@ -19,8 +20,10 @@ tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
   execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
-    t.equal(stderr, '')
-    t.equal(err, null)
+    if (err) {
+      return t.end(err)
+    }
+
     t.equal(stdout.toString(), 'testing\n')
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ tape('set ELECTRON_ENV to development if not defined', function (t) {
     if (err) {
       return t.end(err)
     }
-    t.equal(stdout.toString(), 'development\n')
+    t.equal(stdout.toString().trim(), 'development')
     t.end()
   })
 })
@@ -24,7 +24,7 @@ tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
       return t.end(err)
     }
 
-    t.equal(stdout.toString(), 'testing\n')
+    t.equal(stdout.toString().trim(), 'testing')
     t.end()
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,11 @@ var electron = require('../')
 var path = require('path')
 var pathExists = require('path-exists')
 var getHomePath = require('home-path')()
-var execFile = require('child_process').execFile
+var exec = require('child_process').exec
 
 tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
-  execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+  exec(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
     if (err) {
       return t.end(err)
     }
@@ -19,7 +19,7 @@ tape('set ELECTRON_ENV to development if not defined', function (t) {
 tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
-  execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+  exec(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
     if (err) {
       return t.end(err)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,11 @@ var electron = require('../')
 var path = require('path')
 var pathExists = require('path-exists')
 var getHomePath = require('home-path')()
-var exec = require('child_process').exec
+var execFile = require('child_process').execFile
 
 tape('set ELECTRON_ENV to development if not defined', function (t) {
-  var args = [__dirname + '/fixture/index.js']
-  exec(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+  var args = [__dirname + '/../cli.js', __dirname + '/fixture/index.js']
+  execFile('node', args, function (err, stdout, stderr) {
     if (err) {
       return t.end(err)
     }
@@ -17,9 +17,9 @@ tape('set ELECTRON_ENV to development if not defined', function (t) {
 })
 
 tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
-  var args = [__dirname + '/fixture/index.js']
+  var args = [__dirname + '/../cli.js', __dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
-  exec(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+  execFile('node', args, function (err, stdout, stderr) {
     if (err) {
       return t.end(err)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -3,21 +3,23 @@ var electron = require('../')
 var path = require('path')
 var pathExists = require('path-exists')
 var getHomePath = require('home-path')()
-var spawnSync = require('child_process').spawnSync
+var execFile = require('child_process').execFile
 
 tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
-  var result = spawnSync(__dirname + '/../cli.js', args).stdout.toString()
-  t.equal(result, 'development\n')
-  t.end()
+  execFile(__dirname + '/../cli.js', args, function (err, stdout) {
+    t.equal(stdout.toString(), 'development\n')
+    t.end()
+  })
 })
 
 tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
-  var result = spawnSync(__dirname + '/../cli.js', args).stdout.toString()
-  t.equal(result, 'testing\n')
-  t.end()
+  execFile(__dirname + '/../cli.js', args, function (err, stdout) {
+    t.equal(stdout.toString(), 'testing\n')
+    t.end()
+  })
 })
 
 tape('has local binary', function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,8 @@ var execFile = require('child_process').execFile
 
 tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
-  execFile(__dirname + '/../cli.js', args, function (err, stdout) {
-    t.equal(err, null)
+  execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+    t.equal(stderr, '')
     t.equal(stdout.toString(), 'development\n')
     t.end()
   })
@@ -17,7 +17,8 @@ tape('set ELECTRON_ENV to development if not defined', function (t) {
 tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
-  execFile(__dirname + '/../cli.js', args, function (err, stdout) {
+  execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
+    t.equal(stderr, '')
     t.equal(err, null)
     t.equal(stdout.toString(), 'testing\n')
     t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   execFile(__dirname + '/../cli.js', args, function (err, stdout, stderr) {
     t.equal(stderr, '')
+    t.equal(err, null)
     t.equal(stdout.toString(), 'development\n')
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,22 @@ var electron = require('../')
 var path = require('path')
 var pathExists = require('path-exists')
 var getHomePath = require('home-path')()
+var spawnSync = require('child_process').spawnSync
+
+tape('set ELECTRON_ENV to development if not defined', function (t) {
+  var args = [__dirname + '/fixture/index.js']
+  var result = spawnSync(__dirname + '/../cli.js', args).stdout.toString()
+  t.equal(result, 'development\n')
+  t.end()
+})
+
+tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
+  var args = [__dirname + '/fixture/index.js']
+  process.env.ELECTRON_ENV = 'testing'
+  var result = spawnSync(__dirname + '/../cli.js', args).stdout.toString()
+  t.equal(result, 'testing\n')
+  t.end()
+})
 
 tape('has local binary', function (t) {
   t.ok(pathExists.sync(electron), 'electron was downloaded')

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var execFile = require('child_process').execFile
 tape('set ELECTRON_ENV to development if not defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   execFile(__dirname + '/../cli.js', args, function (err, stdout) {
+    t.equal(err, null)
     t.equal(stdout.toString(), 'development\n')
     t.end()
   })
@@ -17,6 +18,7 @@ tape('inherits ELECTRON_ENV from parent process is defined', function (t) {
   var args = [__dirname + '/fixture/index.js']
   process.env.ELECTRON_ENV = 'testing'
   execFile(__dirname + '/../cli.js', args, function (err, stdout) {
+    t.equal(err, null)
     t.equal(stdout.toString(), 'testing\n')
     t.end()
   })


### PR DESCRIPTION
The env take the value already defined in calling process, defaulting to `development` if it is not defined.