### PR TITLE
Work around {stdio: 'inherit'} not working on Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,9 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'})
+var child = proc.spawn(electron, process.argv.slice(2))
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
 child.on('close', function (code) {
   process.exit(code)
 })


### PR DESCRIPTION
For reasons I cannot fathom, `cli.js` is outputting no stdout/stderr when run in `cmd.exe` on Windows Server 2012 R2 / Node v6.2.2. This patch, which explicitly pipes the fds, works. Head scratcher!
