### PR TITLE
Change platform path to match downloaded one

### DIFF
--- a/install.js
+++ b/install.js
@@ -16,7 +16,7 @@ try {
   // do nothing
 }
 
-var platform = os.platform()
+var platform = process.env.npm_config_platform
 
 function onerror (err) {
   throw err

--- a/install.js
+++ b/install.js
@@ -16,7 +16,7 @@ try {
   // do nothing
 }
 
-var platform = process.env.npm_config_platform
+var platform = process.env.npm_config_platform || os.platform()
 
 function onerror (err) {
   throw err


### PR DESCRIPTION
Hi, I think this issue was related: https://github.com/electron-userland/electron-prebuilt/issues/99

I use Electron as a dependency. The path.txt file had the wrong path when I built for Windows on a Mac using `npm install --platform=win32 --arch=ia32 --production`. The path variable was set to what it would be for my OS's platform, not the target platform. 

If the [platform used to determine the path saved to path.exe](https://github.com/electron-userland/electron-prebuilt/blob/master/install.js#L19) matches [the one downloaded](https://github.com/electron-userland/electron-prebuilt/blob/master/install.js#L39), everything works.

Thanks for everything!