### PR TITLE
clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "electron",
   "version": "1.3.1",
-  "description": "Install electron prebuilt binaries for the command-line use using npm",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/electron-userland/electron-prebuilt.git"
-  },
+  "description": "Install prebuilt electron binaries for the command-line using npm",
+  "repository": "https://github.com/electron-userland/electron-prebuilt",
   "scripts": {
     "cache-clean": "rm -rf ~/.electron && rm -rf dist",
     "postinstall": "node install.js",
@@ -28,12 +25,8 @@
   },
   "author": "Mathias Buus",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/electron-userland/electron-prebuilt/issues"
-  },
-  "homepage": "https://github.com/electron-userland/electron-prebuilt",
   "directories": {
     "test": "test"
   },
-  "keywords": []
+  "keywords": ["electron"]
 }


### PR DESCRIPTION
This makes the package.json file easier for humans to read, without losing any meaningful data. All of these changes are handled in stride by [normalize-package-data](https://github.com/npm/normalize-package-data#what-normalization-currently-entails).

- fix typo in description
- use a terse string URL for `repository`
- use a terse string URL for `bugs`
- npm website uses `repository` in absence of `homepage`, and disregards homepage if it's the same as the repo
