### PR TITLE
Update readme after package rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 releases for this module are handled by https://github.com/johnmuhl/electron-prebuilt-updater
 
-versions published to npm should match the versions published to [github releases for electron](https://github.com/atom/electron/releases)
+versions published to npm should match the versions published to [github releases for electron](https://github.com/electron/electron/releases)
 
 coding style should be `standard`:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![badge](https://nodei.co/npm/electron-prebuilt.png?downloads=true)](https://www.npmjs.com/package/electron-prebuilt)
 
-Install [electron](https://github.com/atom/electron) prebuilt binaries for command-line use using npm. This module helps you easily install the `electron` command for use on the command line without having to compile anything.
+Install [electron](https://github.com/electron/electron) prebuilt binaries for command-line use using npm. This module helps you easily install the `electron` command for use on the command line without having to compile anything.
 
-Electron is a JavaScript runtime that bundles Node.js and Chromium. You use it similar to the `node` command on the command line for executing JavaScript programs. For more info you can read [this intro blog post](http://maxogden.com/electron-fundamentals.html) or dive into the [Electron documentation](https://github.com/atom/electron/tree/master/docs)
+Electron is a JavaScript runtime that bundles Node.js and Chromium. You use it similar to the `node` command on the command line for executing JavaScript programs. For more info you can read [this intro blog post](http://maxogden.com/electron-fundamentals.html) or dive into the [Electron documentation](https://github.com/electron/electron/tree/master/docs)
 
 ## Installation
 
@@ -45,15 +45,15 @@ npm install --arch=ia32 electron
 
 ## About
 
-Works on Mac, Windows and Linux OSes that Electron supports (e.g. Electron [does not support Windows XP](https://github.com/atom/electron/issues/691)).
+Works on Mac, Windows and Linux OSes that Electron supports (e.g. Electron [does not support Windows XP](https://github.com/electron/electron/issues/691)).
 
-The version numbers of this module match the version number of the [offical Electron releases](https://github.com/atom/electron/releases), which do not follow [semantic versioning](http://semver.org/).
+The version numbers of this module match the version number of the [offical Electron releases](https://github.com/electron/electron/releases), which do not follow [semantic versioning](http://semver.org/).
 
 This module is automatically released whenever a new version of Electron is released thanks to [electron-prebuilt-updater](https://github.com/johnmuhl/electron-prebuilt-updater) written by [John Muhl](https://github.com/johnmuhl/).
 
 ## Usage
 
-First you have to [write an electron application](https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md)
+First you have to [write an electron application](https://github.com/electron/electron/blob/master/docs/tutorial/quick-start.md)
 
 Then you can run your app using:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Electron is a JavaScript runtime that bundles Node.js and Chromium. You use it s
 Download and install the latest build of electron for your OS and add it to your projects `package.json` as a `devDependency`:
 
 ```
-npm install electron-prebuilt --save-dev
+npm install electron --save-dev
 ```
 
 This is the preferred way to use electron, as it doesn't require users to install electron globally.
@@ -21,13 +21,13 @@ This is the preferred way to use electron, as it doesn't require users to instal
 You can also use the `-g` flag (global) to symlink it into your PATH:
 
 ```
-npm install -g electron-prebuilt
+npm install -g electron
 ```
 
 If that command fails with an `EACCESS` error you may have to run it again with `sudo`:
 
 ```
-sudo npm install -g electron-prebuilt
+sudo npm install -g electron
 ```
 
 Now you can just run `electron` to run electron:
@@ -40,7 +40,7 @@ If you need to use an HTTP proxy you can [set these environment variables](https
 
 If you want to change the architecture that is downloaded (e.g., `ia32` on an `x64` machine), you can use the `--arch` flag with npm install or set the `npm_config_arch` environment variable:
 ```
-npm install --arch=ia32 electron-prebuilt
+npm install --arch=ia32 electron
 ```
 
 ## About
@@ -71,11 +71,12 @@ Find more at the [awesome-electron](https://github.com/sindresorhus/awesome-elec
 
 ## Programmatic usage
 
-Most people use this from the command line, but if you require `electron-prebuilt` inside your node app it will return the file path to the binary.
-Use this to spawn electron from node scripts.
+Most people use this from the command line, but if you require `electron` inside
+your **node app** (not your electron app) it will return the file path to the
+binary. Use this to spawn electron from node scripts:
 
 ``` js
-var electron = require('electron-prebuilt')
+var electron = require('electron')
 var proc = require('child_process')
 
 // will something similar to print /Users/maf/.../Electron

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 Install [electron](https://github.com/electron/electron) prebuilt binaries for command-line use using npm. This module helps you easily install the `electron` command for use on the command line without having to compile anything.
 
-Electron is a JavaScript runtime that bundles Node.js and Chromium. You use it similar to the `node` command on the command line for executing JavaScript programs. For more info you can read [this intro blog post](http://maxogden.com/electron-fundamentals.html) or dive into the [Electron documentation](https://github.com/electron/electron/tree/master/docs)
+[Electron](http://electron.atom.io) is a JavaScript runtime that bundles Node.js
+and Chromium. You use it similar to the `node` command on the command line for
+executing JavaScript programs. For more info you can read [this intro blog post](http://maxogden.com/electron-fundamentals.html) or dive into the [Electron documentation](http://electron.atom.io/docs)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@ executing JavaScript programs. For more info you can read [this intro blog post]
 
 ## Installation
 
-Download and install the latest build of electron for your OS and add it to your projects `package.json` as a `devDependency`:
+**Note** As of version 1.3.1, this package is published to npm under two names:
+`electron` and `electron-prebuilt`. You can currently use either name, but
+`electron` is recommended, as the `electron-prebuilt` name is deprecated, and
+will only be published until the end of 2016.
+
+Download and install the latest build of electron for your OS and add it to your
+project's `package.json` as a `devDependency`:
 
 ```
 npm install electron --save-dev
 ```
 
-This is the preferred way to use electron, as it doesn't require users to install electron globally.
+This is the preferred way to use electron, as it doesn't require users to
+install electron globally.
 
 You can also use the `-g` flag (global) to symlink it into your PATH:
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,6 +1,6 @@
-If there is an existing Electron issue for this, please link it here:
+If you're having an issue _installing_ Electron, this is the place to report it.
 
-https://github.com/atom/electron/issues
+If you're having an issue _using_ Electron, please report it at https://github.com/electron/electron/issues
 
-Describe your problem:
-
+* Electron version:
+* Operating system:


### PR DESCRIPTION
This change updates the readme:

- Fix old repo URLs
- Point to docs on website
- Use `npm install electron`

cc @jlord @kevinsawicki