### PR TITLE
Mention builds not available when platform not found

### DIFF
--- a/install.js
+++ b/install.js
@@ -29,7 +29,7 @@ var paths = {
   win32: 'dist/electron.exe'
 }
 
-if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
+if (!paths[platform]) throw new Error('Electron builds are not available on platform: ' + platform)
 
 if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[platform]))) {
   process.exit(0)


### PR DESCRIPTION
This pull request tweaks the error message for unsupported platforms to hopefully be a little clearer about the error when a platform build of Electron is unavailable.

It changes it from:

> Unknown platform: n64

to:

> Electron builds are not available on platform: n64
