### PR TITLE
Upgrade electron-download for checksum support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,8 @@
 dist/
 path.txt
+.npmignore
+.travis.yml
+appveyor.yml
+CONTRIBUTING.md
+issue_template.md
+test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ node_js:
 branches:
   only:
   - master
+install:
+  - npm --silent install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+os:
+- linux
+- osx
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
-  - 'iojs'
+- '4'
+- '5'
+- '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
 - osx
 language: node_js
 node_js:
+- '0.10'
+- '0.12'
 - '4'
 - '5'
 - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ node_js:
 - '4'
 - '5'
 - '6'
+branches:
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # electron-prebuilt
 
-[![build status](http://img.shields.io/travis/electron-userland/electron-prebuilt.svg?style=flat)](http://travis-ci.org/electron-userland/electron-prebuilt)
+[![Travis build status](http://img.shields.io/travis/electron-userland/electron-prebuilt.svg?style=flat)](http://travis-ci.org/electron-userland/electron-prebuilt)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/qd978ky9axl8m1m1?svg=true)](https://ci.appveyor.com/project/Atom/electron-prebuilt)
 
 [![badge](https://nodei.co/npm/electron-prebuilt.png?downloads=true)](https://www.npmjs.com/package/electron-prebuilt)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+build: off
+
+branches:
+  only:
+    - master
+
+environment:
+  matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
+  - nodejs_version: "4"
+  - nodejs_version: "5"
+  - nodejs_version: "6"
+
+skip_tags: true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install npm
+  - .\node_modules\.bin\npm install
+
+test_script:
+  - node --version
+  - .\node_modules\.bin\npm --version
+  - .\node_modules\.bin\npm test

--- a/install.js
+++ b/install.js
@@ -41,7 +41,7 @@ download({
   platform: process.env.npm_config_platform,
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
-  quiet: process.env.npm_config_loglevel === 'silent',
+  quiet: process.env.npm_config_loglevel === 'silent'
 }, extractFile)
 
 // unzips and makes path.txt point at the correct executable

--- a/install.js
+++ b/install.js
@@ -36,7 +36,13 @@ if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[pla
 }
 
 // downloads if not cached
-download({version: version, platform: process.env.npm_config_platform, arch: process.env.npm_config_arch, strictSSL: process.env.npm_config_strict_ssl === 'true'}, extractFile)
+download({
+  version: version,
+  platform: process.env.npm_config_platform,
+  arch: process.env.npm_config_arch,
+  strictSSL: process.env.npm_config_strict_ssl === 'true',
+  quiet: process.env.npm_config_loglevel === 'silent',
+}, extractFile)
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "extract-zip": "^1.0.3",
-    "electron-download": "^2.2.0"
+    "electron-download": "^3.0.0"
   },
   "devDependencies": {
     "home-path": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   "main": "index.js",
   "dependencies": {
     "extract-zip": "^1.0.3",
-    "electron-download": "^2.0.0"
+    "electron-download": "^2.2.0"
   },
   "devDependencies": {
     "home-path": "^0.1.1",
-    "path-exists": "^1.0.0",
+    "path-exists": "^2.0.0",
     "standard": "^5.4.1",
     "tape": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "cache-clean": "rm -rf ~/.electron && rm -rf dist",
     "postinstall": "node install.js",
-    "pretest": "npm run cache-clean && node install.js",
-    "test": "standard && tape test/*.js"
+    "pretest": "npm run cache-clean && npm --silent run postinstall",
+    "test": "tape test/*.js && standard"
   },
   "bin": {
     "electron": "cli.js"


### PR DESCRIPTION
I'm updating the version number to force an upgrade.

Also, update Travis to test against Node >= 4 on Linux and OSX.

Oddly enough, I had to upgrade `path-exists` as well, otherwise it wouldn't download correctly.

Fixes #51.