### PR TITLE
Upgrade electron download to fix Mac CI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ node_js:
 branches:
   only:
   - master
-install:
-  - npm --silent install

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cache-clean": "rm -rf ~/.electron && rm -rf dist",
     "postinstall": "node install.js",
-    "pretest": "npm run cache-clean && npm --silent run postinstall",
+    "pretest": "npm run cache-clean && npm run postinstall",
     "test": "tape test/*.js && standard"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "extract-zip": "^1.0.3",
-    "electron-download": "^3.0.0"
+    "electron-download": "^3.0.1"
   },
   "devDependencies": {
     "home-path": "^0.1.1",


### PR DESCRIPTION
Upgrade to an `electron-download` version that includes https://github.com/electron-userland/electron-download/pull/35

Closes #193 