### PR TITLE
Download progress should only show for appropriate log levels

### DIFF
--- a/install.js
+++ b/install.js
@@ -41,7 +41,7 @@ download({
   platform: process.env.npm_config_platform,
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
-  quiet: process.env.npm_config_loglevel === 'silent'
+  quiet: ['info', 'verbose', 'silly'].indexOf(process.env.npm_config_loglevel) === -1
 }, extractFile)
 
 // unzips and makes path.txt point at the correct executable


### PR DESCRIPTION
`electron-download` progress should be suppressed for anything but `info`, `verbose` and `silly` npm log levels. 

I don't know if this will be surprising for anyone having a default npm `warn` level, as you wouldn't see the specific progress (and possibly think it's broken), but just having `silent` as the switch to turn off progress is very inconvenient for automated build logs.

What do you guys think?
