### PR TITLE
Forward kill signals to child process

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,3 +8,10 @@ var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'})
 child.on('close', function (code) {
   process.exit(code)
 })
+
+var forwardedSignals = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']
+forwardedSignals.forEach(function(signal) {
+  process.on(signal, function() { if (child) child.kill(signal); })
+})
+
+process.on('exit', function() { if (child) child.kill() })


### PR DESCRIPTION
If you launch the cli via a process like npm start, then fire
SIGINT (via ctrl-c), the child Electron process will not terminate. This
forwards the most common kill signals onto the child process

While not necessary on Linux, OSX will not kill the process unless the signals are manually passed.