### PR TITLE
Check that the path file exists before spawning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var fs = require('fs')
 var path = require('path')
 
-const pathFile = path.join(__dirname, 'path.txt')
+var pathFile = path.join(__dirname, 'path.txt')
 
 if (fs.existsSync(pathFile)) {
   module.exports = path.join(__dirname, fs.readFileSync(pathFile, 'utf-8'))
 } else {
-  throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again');
+  throw new Error('Electron failed to install correctly, please delete node_modules/' + path.basename(__dirname) + ' and try installing again');
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 var fs = require('fs')
 var path = require('path')
 
-module.exports = path.join(__dirname, fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8'))
+const pathFile = path.join(__dirname, 'path.txt')
+
+if (fs.existsSync(pathFile)) {
+  module.exports = path.join(__dirname, fs.readFileSync(pathFile, 'utf-8'))
+} else {
+  throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again');
+}

--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@ var pathFile = path.join(__dirname, 'path.txt')
 if (fs.existsSync(pathFile)) {
   module.exports = path.join(__dirname, fs.readFileSync(pathFile, 'utf-8'))
 } else {
-  throw new Error('Electron failed to install correctly, please delete node_modules/' + path.basename(__dirname) + ' and try installing again');
+  throw new Error('Electron failed to install correctly, please delete node_modules/' + path.basename(__dirname) + ' and try installing again')
 }


### PR DESCRIPTION
This is to handle issues such as https://github.com/electron/electron-quick-start/issues/122 where the install either terminated early or failed for whatever reason.  We can throw a more descriptive error in this case.