### PR TITLE
Write path.txt file after uncompressing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 path.txt
 .DS_Store
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ appveyor.yml
 CONTRIBUTING.md
 issue_template.md
 test/
+npm-debug.log

--- a/install.js
+++ b/install.js
@@ -12,7 +12,7 @@ var download = require('electron-download')
 var installedVersion = null
 try {
   installedVersion = fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '')
-} catch (err) {
+} catch (ignored) {
   // do nothing
 }
 

--- a/install.js
+++ b/install.js
@@ -47,9 +47,9 @@ download({
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {
   if (err) return onerror(err)
-  fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
+  extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
     if (err) return onerror(err)
-    extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
+    fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
       if (err) return onerror(err)
     })
   })

--- a/install.js
+++ b/install.js
@@ -22,16 +22,23 @@ function onerror (err) {
   throw err
 }
 
-var paths = {
-  darwin: 'dist/Electron.app/Contents/MacOS/Electron',
-  freebsd: 'dist/electron',
-  linux: 'dist/electron',
-  win32: 'dist/electron.exe'
+function getPath (platform) {
+  switch (platform) {
+    case 'darwin':
+      return 'dist/Electron.app/Contents/MacOS/Electron'
+    case 'freebsd':
+    case 'linux':
+      return 'dist/electron'
+    case 'win32':
+      return 'dist/electron.exe'
+    default:
+      throw new Error('Electron builds are not available on platform: ' + platform)
+  }
 }
 
-if (!paths[platform]) throw new Error('Electron builds are not available on platform: ' + platform)
+var platformPath = getPath(platform)
 
-if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[platform]))) {
+if (installedVersion === version && fs.existsSync(path.join(__dirname, platformPath))) {
   process.exit(0)
 }
 
@@ -49,7 +56,7 @@ function extractFile (err, zipPath) {
   if (err) return onerror(err)
   extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
     if (err) return onerror(err)
-    fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
+    fs.writeFile(path.join(__dirname, 'path.txt'), platformPath, function (err) {
       if (err) return onerror(err)
     })
   })

--- a/install.js
+++ b/install.js
@@ -16,27 +16,7 @@ try {
   // do nothing
 }
 
-var platform = process.env.npm_config_platform || os.platform()
-
-function onerror (err) {
-  throw err
-}
-
-function getPath (platform) {
-  switch (platform) {
-    case 'darwin':
-      return 'dist/Electron.app/Contents/MacOS/Electron'
-    case 'freebsd':
-    case 'linux':
-      return 'dist/electron'
-    case 'win32':
-      return 'dist/electron.exe'
-    default:
-      throw new Error('Electron builds are not available on platform: ' + platform)
-  }
-}
-
-var platformPath = getPath(platform)
+var platformPath = getPlatformPath()
 
 if (installedVersion === version && fs.existsSync(path.join(__dirname, platformPath))) {
   process.exit(0)
@@ -60,4 +40,24 @@ function extractFile (err, zipPath) {
       if (err) return onerror(err)
     })
   })
+}
+
+function onerror (err) {
+  throw err
+}
+
+function getPlatformPath () {
+  var platform = process.env.npm_config_platform || os.platform()
+
+  switch (platform) {
+    case 'darwin':
+      return 'dist/Electron.app/Contents/MacOS/Electron'
+    case 'freebsd':
+    case 'linux':
+      return 'dist/electron'
+    case 'win32':
+      return 'dist/electron.exe'
+    default:
+      throw new Error('Electron builds are not available on platform: ' + platform)
+  }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -6,7 +6,7 @@ var childProcess = require('child_process')
 tape('fails for unsupported platforms', function (t) {
   install({npm_config_platform: 'android'}, function (code, stderr) {
     t.notEqual(stderr.indexOf('Electron builds are not available on platform: android'), -1, 'has error message')
-    t.equal(code, 1, 'exited with 1')
+    t.notEqual(code, 0, 'exited with error')
     t.end()
   })
 })
@@ -20,7 +20,7 @@ tape('fails for unknown architectures', function (t) {
   }, function (code, stderr) {
     t.notEqual(stderr.indexOf('Failed to find Electron'), -1, 'has error message')
     t.notEqual(stderr.indexOf('win32-midcentury'), -1, 'has error message')
-    t.equal(code, 1, 'exited with 1')
+    t.notEqual(code, 0, 'exited with error')
     t.end()
   })
 })

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,62 @@
+var fs = require('fs')
+var tape = require('tape')
+var path = require('path')
+var childProcess = require('child_process')
+
+tape('fails for unsupported platforms', function (t) {
+  install({npm_config_platform: 'android'}, function (code, stderr) {
+    t.notEqual(stderr.indexOf('Electron builds are not available on platform: android'), -1, 'has error message')
+    t.equal(code, 1, 'exited with 1')
+    t.end()
+  })
+})
+
+tape('fails for unknown architectures', function (t) {
+  install({
+    npm_config_arch: 'midcentury',
+    npm_config_platform: 'win32',
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE
+  }, function (code, stderr) {
+    t.notEqual(stderr.indexOf('Failed to find Electron'), -1, 'has error message')
+    t.notEqual(stderr.indexOf('win32-midcentury'), -1, 'has error message')
+    t.equal(code, 1, 'exited with 1')
+    t.end()
+  })
+})
+
+var install = function (env, callback) {
+  removeVersionFile()
+
+  var installPath = path.join(__dirname, '..', 'install.js')
+  var installProcess = childProcess.fork(installPath, {
+    silent: true,
+    env: env
+  })
+
+  var stderr = ''
+  installProcess.stderr.on('data', function (data) {
+    stderr += data
+  })
+
+  installProcess.on('close', function (code) {
+    restoreVersionFile()
+    callback(code, stderr)
+  })
+}
+
+var versionPath = path.join(__dirname, '..', 'dist', 'version')
+var versionContents = null
+function removeVersionFile () {
+  if (fs.existsSync(versionPath)) {
+    versionContents = fs.readFileSync(versionPath)
+    fs.unlinkSync(versionPath)
+  }
+}
+
+function restoreVersionFile () {
+  if (versionContents != null) {
+    fs.writeFileSync(versionPath, versionContents)
+    versionContents = null
+  }
+}


### PR DESCRIPTION
This pull request updates the install sequence to write the `path.txt` file last, after uncompressing has happened. This way it is only written if downloading and extracting both succeed.

This will make it easier to check for errors when launching a possibly corrupted install via #224.

Also adds a few specs for failure cases to guard against regressions.
