### PR TITLE
Use preinstall instead of postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/electron-userland/electron-prebuilt",
   "scripts": {
     "cache-clean": "rm -rf ~/.electron && rm -rf dist",
-    "postinstall": "node install.js",
+    "preinstall": "node install.js",
     "pretest": "npm run cache-clean && npm run postinstall",
     "test": "tape test/*.js && standard"
   },


### PR DESCRIPTION
`npm install electron` downloads and unzips ~40MB the first time it is run.

This can take some time in certain environment and people installing it seem to interrupt it with `Control-C` often leading to error reports like `Error: ENOENT: no such file or directory, open '/Users/travis/build/beep/boop/node_modules/electron/path.txt'`. This is because `node_modules/.bin/electron` is created but launching it will still fail since the distribution is missing/incomplete/corrupt.

This pull request switches it to be a `preinstall` instead of `postinstall`. This means it will run when the package is in `node_modules/.staging` folder and so it won't be marked as installed when it is interrupted.
