### PR TITLE
Update README.md badge: Drop prebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis build status](http://img.shields.io/travis/electron-userland/electron-prebuilt.svg?style=flat)](http://travis-ci.org/electron-userland/electron-prebuilt)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/qd978ky9axl8m1m1?svg=true)](https://ci.appveyor.com/project/Atom/electron-prebuilt)
 
-[![badge](https://nodei.co/npm/electron-prebuilt.png?downloads=true)](https://www.npmjs.com/package/electron-prebuilt)
+[![badge](https://nodei.co/npm/electron.png?downloads=true)](https://www.npmjs.com/package/electron)
 
 Install [Electron](https://github.com/electron/electron) prebuilt binaries for
 command-line use using npm. This module helps you easily install the `electron`


### PR DESCRIPTION
As documented later in the README.md already, plus the download numbers look bigger too.