### PR TITLE
Use process.env.electron_config_cache to get the released zip file from the local directory during installation of Electron.

### DIFF
--- a/install.js
+++ b/install.js
@@ -24,6 +24,7 @@ if (installedVersion === version && fs.existsSync(path.join(__dirname, platformP
 
 // downloads if not cached
 download({
+  cache: process.env.electron_config_cache,
   version: version,
   platform: process.env.npm_config_platform,
   arch: process.env.npm_config_arch,


### PR DESCRIPTION
Sometimes there is no access to GitHub on the build machines.
But Electron during the installation downloads released zip file from https://github.com/electron/electron/releases.
Prepared zip files could be stored by the maintainer of the build machine to some local directory.
This fix allows to use the local cache with released zip files during installation of Electron.