### PR TITLE
Postinstall is broken. Frozen extract-zip version to 1.5.0 resolve th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Install prebuilt electron binaries for the command-line using npm",
   "repository": "https://github.com/electron-userland/electron-prebuilt",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "extract-zip": "^1.0.3",
+    "extract-zip": "1.5.0",
     "electron-download": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,
Postinstall is broken. I try different things. Locking extract-zip version to 1.5 make postinstall and the tests work.