### PR TITLE
set fixed version for extract-zip to fix failing electron installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "extract-zip": "^1.0.3",
+    "extract-zip": "1.6.0",
     "electron-download": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As discussed [here](https://github.com/electron/electron/issues/9323#issuecomment-298203891).