### PR TITLE
add @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   "main": "index.js",
   "types": "electron.d.ts",
   "dependencies": {
-    "extract-zip": "^1.0.3",
-    "electron-download": "^3.0.1"
+    "@types/node": "^7.0.18",
+    "electron-download": "^3.0.1",
+    "extract-zip": "^1.0.3"
   },
   "devDependencies": {
     "home-path": "^0.1.1",


### PR DESCRIPTION
This PR adds `@types/node` as a dependency.

Pros

 - This will make `npm install electron` take care of adding everything that TypeScript users will need when writing Electron apps.

Cons

- People who don't use TypeScript are needlessly downloading an extra dependency. (Though it is small, inert, and has no dependencies)
- Most TypeScript users [are already accustomed](https://github.com/electron/electron-typescript-definitions/issues/43#issuecomment-300687960) to adding `@types/node` to their projects, and it appears that Visual Studio Code [bundles the node types by default](https://github.com/electron/electron-typescript-definitions/issues/43#issuecomment-300691565).
- It's a scoped package, which has a slightly higher degree of vendor lock-in than a package in the global npm namespace.

I want to optimize for the principle of least surprise. My sense is that this change will give TypeScripters what they want, and the non-TypeScripters probably won't even notice.

Would love thoughts from @MarshallOfSound @shiftkey @poiru @kevinsawicki 