### PR TITLE
added force option for electron-download inside install.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ If you want to change the architecture that is downloaded (e.g., `ia32` on an
 npm install --arch=ia32 electron
 ```
 
+If you need to force a re-download of the asset and the SHASUM file set the `force_no_cache` enviroment variable to true.
+
 ## About
 
 Works on Mac, Windows and Linux OSes that Electron supports (e.g. Electron

--- a/install.js
+++ b/install.js
@@ -29,6 +29,7 @@ download({
   platform: process.env.npm_config_platform,
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
+  force: process.env.force_no_cache || false,
   quiet: ['info', 'verbose', 'silly', 'http'].indexOf(process.env.npm_config_loglevel) === -1
 }, extractFile)
 

--- a/install.js
+++ b/install.js
@@ -29,7 +29,7 @@ download({
   platform: process.env.npm_config_platform,
   arch: process.env.npm_config_arch,
   strictSSL: process.env.npm_config_strict_ssl === 'true',
-  force: process.env.force_no_cache || false,
+  force: process.env.force_no_cache === 'true',
   quiet: ['info', 'verbose', 'silly', 'http'].indexOf(process.env.npm_config_loglevel) === -1
 }, extractFile)
 


### PR DESCRIPTION
Downloading from cache causes a checksum check that causes some builds to fail(see https://github.com/electron/electron/issues/8653) that  that rely on stable electron releases(pre electron v1.7.0 beta) where chromedrive is not named based on electron version. This will add the option to always force a redownload.