### PR TITLE
bump @types/node to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "types": "electron.d.ts",
   "dependencies": {
-    "@types/node": "^7.0.18",
+    "@types/node": "^8.0.19",
     "electron-download": "^3.0.1",
     "extract-zip": "^1.0.3"
   },


### PR DESCRIPTION
Electron 1.8 will be shipping with Chromium 59 and [Node 8.2.1](https://github.com/electron/electron/pull/9992) 🎉 

This PR should be merged just before we release Electron 1.8